### PR TITLE
Add schedule management calendar app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # Project
+
+This repository contains a simple schedule management calendar app written in Python.
+
+## Usage
+
+Run the following commands to manage events:
+
+- Add an event:
+  ```bash
+  python calendar_app.py add --date YYYY-MM-DD --time HH:MM --description "Event description"
+  ```
+- List events (for a specific date or all):
+  ```bash
+  python calendar_app.py list --date YYYY-MM-DD  # omit --date to list all
+  ```
+- Remove an event by index:
+  ```bash
+  python calendar_app.py remove --date YYYY-MM-DD --index N
+  ```
+
+Events are stored in `calendar_data.json` in JSON format.
+
+## Testing
+
+Run `pytest` to execute the unit tests.

--- a/calendar_app.py
+++ b/calendar_app.py
@@ -1,0 +1,78 @@
+import argparse
+import json
+from pathlib import Path
+
+DATA_FILE = Path('calendar_data.json')
+
+
+def load_data():
+    if DATA_FILE.exists():
+        with open(DATA_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {}
+
+
+def save_data(data):
+    with open(DATA_FILE, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def add_event(date, time, description):
+    data = load_data()
+    events = data.setdefault(date, [])
+    events.append({"time": time, "description": description})
+    save_data(data)
+
+
+def list_events(date=None):
+    data = load_data()
+    if date:
+        events = data.get(date, [])
+        return {date: events}
+    return data
+
+
+def remove_event(date, index):
+    data = load_data()
+    events = data.get(date)
+    if not events:
+        raise ValueError("No events on that date")
+    if index < 0 or index >= len(events):
+        raise IndexError("Event index out of range")
+    events.pop(index)
+    if not events:
+        data.pop(date)
+    else:
+        data[date] = events
+    save_data(data)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Simple schedule management")
+    subparsers = parser.add_subparsers(dest='command', required=True)
+
+    parser_add = subparsers.add_parser('add')
+    parser_add.add_argument('--date', required=True, help='YYYY-MM-DD')
+    parser_add.add_argument('--time', required=True, help='HH:MM')
+    parser_add.add_argument('--description', required=True)
+
+    parser_list = subparsers.add_parser('list')
+    parser_list.add_argument('--date', help='YYYY-MM-DD')
+
+    parser_remove = subparsers.add_parser('remove')
+    parser_remove.add_argument('--date', required=True, help='YYYY-MM-DD')
+    parser_remove.add_argument('--index', type=int, required=True)
+
+    args = parser.parse_args(argv)
+
+    if args.command == 'add':
+        add_event(args.date, args.time, args.description)
+    elif args.command == 'list':
+        events = list_events(args.date)
+        print(json.dumps(events, ensure_ascii=False, indent=2))
+    elif args.command == 'remove':
+        remove_event(args.date, args.index)
+
+
+if __name__ == '__main__':
+    main()

--- a/test_calendar_app.py
+++ b/test_calendar_app.py
@@ -1,0 +1,23 @@
+import os
+import calendar_app
+
+
+def setup_function():
+    if os.path.exists(calendar_app.DATA_FILE):
+        os.remove(calendar_app.DATA_FILE)
+
+
+def test_add_and_list(tmp_path):
+    calendar_app.DATA_FILE = tmp_path / "data.json"
+    calendar_app.add_event("2024-01-01", "10:00", "New Year Celebration")
+    events = calendar_app.list_events("2024-01-01")
+    assert events == {"2024-01-01": [{"time": "10:00", "description": "New Year Celebration"}]}
+
+
+def test_remove(tmp_path):
+    calendar_app.DATA_FILE = tmp_path / "data.json"
+    calendar_app.add_event("2024-01-02", "09:00", "Meeting")
+    calendar_app.add_event("2024-01-02", "15:00", "Another Meeting")
+    calendar_app.remove_event("2024-01-02", 0)
+    events = calendar_app.list_events("2024-01-02")
+    assert events == {"2024-01-02": [{"time": "15:00", "description": "Another Meeting"}]}


### PR DESCRIPTION
## Summary
- implement a simple CLI calendar app
- add tests for scheduling functions
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868d53386dc83329dfefb73b7690c54